### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   }],
   "require": {
     "php": ">=5.5",
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": "~6.0 || ~7.0"
   },
   "require-dev": {
     "ext-curl": "*",


### PR DESCRIPTION
the changes from Guzzle 6 to 7 are actually small for basic integrations, so this should be safe.